### PR TITLE
Base.download is deprecated

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,18 +1,19 @@
+using Downloads
 if Sys.isapple()
     url = "https://github.com/sglyon/MINPACK.jl/releases/download/v0.0.0/libcminpack.dylib"
-    download(url, joinpath(dirname(@__FILE__), "libcminpack.dylib"))
+    Downloads.download(url, joinpath(dirname(@__FILE__), "libcminpack.dylib"))
 elseif Sys.iswindows()
     if Sys.WORD_SIZE == 64
         dll_url = "https://github.com/sglyon/MINPACK.jl/releases/download/v0.0.0/libcminpack.dll"
     else
         dll_url = "https://github.com/sglyon/MINPACK.jl/releases/download/v0.0.0/libcminpack32.dll"
     end
-    download(dll_url, joinpath(dirname(@__FILE__), "libcminpack.dll"))
+    Downloads.download(dll_url, joinpath(dirname(@__FILE__), "libcminpack.dll"))
 elseif Sys.islinux()
     if Sys.WORD_SIZE == 64
         so_url = "https://github.com/sglyon/MINPACK.jl/releases/download/v0.0.0/libcminpack.so"
     else
         so_url = "https://github.com/sglyon/MINPACK.jl/releases/download/v0.0.0/libcminpack32.so"
     end
-    download(so_url, joinpath(dirname(@__FILE__), "libcminpack.so"))
+    Downloads.download(so_url, joinpath(dirname(@__FILE__), "libcminpack.so"))
 end


### PR DESCRIPTION
In the SciML organization, we are trying to make all tests throw errors on deprecation warnings.
The tests in LinearSolve.jl stumble over a deprecation of the download function in this package:
https://github.com/SciML/LinearSolve.jl/actions/runs/9061500261/job/24893380912?pr=501#step:7:390
This PR should get rid of the deprecation warning. 

